### PR TITLE
Added CATEGORIES field to events exported as ICS

### DIFF
--- a/src/core/utils/schedule.ts
+++ b/src/core/utils/schedule.ts
@@ -94,6 +94,7 @@ const toICS = (schedule: ISchedule[]): Blob => {
     const title = `${pair.numberPair}: (${pair.type}) ${pair.subject.title}`
     const teachersString = stringifyTeachers(pair.teachers)
     const description = `Викладач(і): ${teachersString.length === 0 ? 'Немає' : teachersString}`
+    const category = `${pair.type}`
 
     ics += 'BEGIN:VEVENT\n'
     ics += `SUMMARY:${title}\n`
@@ -101,6 +102,7 @@ const toICS = (schedule: ISchedule[]): Blob => {
     ics += `DTEND:${toICVFormat(pair.endTime)}\n`
     ics += `LOCATION:${pair.auditory}\n`
     ics += `DESCRIPTION:${description}\n`
+    ics += `CATEGORIES:${category}\n`
     ics += 'END:VEVENT\n'
   }
 


### PR DESCRIPTION
Більшість календарів підтримують встановлення категорій для подій. У вигляді категорії можна зберігати тип пари (Лк, Лб, Пз і так далі).

Приклад з Thunderbird.

Без категорій
![Image](https://github.com/user-attachments/assets/27504c2a-3a5a-4f75-bccb-258bcd322398)

З категоріями:
![Image](https://github.com/user-attachments/assets/6331a7a3-6a59-4d09-8586-42fdc6e14ca4)